### PR TITLE
scenegraph management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ data/*
 
 assets/demo_frames/*
 openeqa/models/*
+
+*typ
+*pdf

--- a/openeqa/utils/scenegraph_utils.py
+++ b/openeqa/utils/scenegraph_utils.py
@@ -1,0 +1,43 @@
+import json
+import os
+
+class ScenegraphManager():
+    scenegraphs_per_episode = {}
+   
+    def set_scenegraphs(self) -> None: # set scenegraphs from json files
+        for filename in os.listdir('data/scenegraphs'):
+            with open(f'data/scenegraphs/{filename}', 'r') as file:
+                data = json.load(file)
+            
+        for episode_id, scenegraph in data.items(): # mapping data to scenegraphs_per_episode
+            self.scenegraphs_per_episode[episode_id] = scenegraph
+
+    def has_episode(self, episode_id) -> bool: # check if episode exists
+      return episode_id in self.scenegraphs_per_episode.keys()
+        
+    def get_scenegraph_path(self, episode_id) -> str: # get path of scenegraph of episode
+        return f'data/scenegraphs/{episode_id}.json'
+
+    def add_episode(self, episode_id) -> None: # add new episode
+        if episode_id in self.scenegraphs_per_episode.keys():
+            raise Exception("Episode already exists")
+        else:
+            self.scenegraphs_per_episode[episode_id] = {}
+
+    def update_scenegraph(self, episode_id, new_scenegraph) -> None: # update scenegraph of episode and save to file
+        self.has_episode(episode_id)
+        self.scenegraphs_per_episode[episode_id] = new_scenegraph
+
+        with open(self.get_scenegraph_path(episode_id), 'w') as file:
+            json.dump(new_scenegraph, file)
+
+        
+
+'''scenegraph_per_episode 의 구성
+{
+  "episode 1" : {유정이가 만드는 scenegraph},
+  "episode 2" : {"},
+  "episode 3" : {"},
+  ...
+}
+'''


### PR DESCRIPTION
(주석# 옆에 ?,*,! 등의 기호는 vscode extension - better comments 설치하면 주석을 종류별로 구분해서 볼 수 있는데 그거 때문에 그렇게 돼 있어요.. 추천..)

---

- [x] scenegraphs 전역 관리
- [x] episode 별 scenegraph 유무에 따라 create/update API 다르게 적용
    - [x] create API
    - [x] update API
        해당 과정에서 episode_id.json 이라는 file 을 첨부해서 전달해야 하기 때문에, 기존의 chat api 가 아닌 thread api 이용
- [x] image 받아서 suffix(user query) 없이 scenegraph만 생성하는 api 작성
        data/scenegraph/ 가 빈 레포면 gpt4o 돌렸을 때 해당 기능을 수행합니다.
- [ ] IndexIndicator 적용
- [ ] ScenegraphManager 동작 테스트
    - [x] prompt 가 scenegraph를 json형태로 예쁘게 안 뱉어줘서, parsing 이 안돼서 response에서 scenegraph 추출이 안됨 
- [ ] IndexIndicator 연계 동작 테스트
- [ ] 일련의 과정(초기 scenegraph 생성 -> 각 쿼리마다 scenegraph 업데이트 후 answer 생성 시 반영) 동작 테스트

---
### Issue

- [ ] episode 별 scenegraph 유무에 따라 서로 다른 prompt 적용 : 현재 단계에서는 보류
- [ ] scenegraph 를 파일로 관리하게 되면서, 쿼리마다 json r,w 작업 반복되는 이슈가 있음. 다른 episode 로 전환될 때만 w 하고, 그 전까지는 dictionary 만 업데이트하면서 사용해도 될 듯함.